### PR TITLE
Fix authors string issue

### DIFF
--- a/drafttopic/about.py
+++ b/drafttopic/about.py
@@ -1,7 +1,7 @@
 __name__ = "drafttopic"
 __version__ = "0.1.1"
-__author__ = ["Aaron Halfaker", "Sumit Asthana"]
-__author_email__ = ["ahalfaker@wikimedia.org", "asthana.sumit23@gmail.com"]
+__author__ = "Aaron Halfaker, Sumit Asthana"
+__author_email__ = "ahalfaker@wikimedia.org, asthana.sumit23@gmail.com"
 __description__ = "A library for automatic detection of topics of new " +\
     "drafts on Wikipedia based on WikiProjects."
 __url__ = "https://github.com/wikimedia/drafttopic"


### PR DESCRIPTION
This PR fixes an issue which cause the build to fail.

```
HTTPError: 400 Client Error: "['ahalfaker@wikimedia.org', 'asthana.sumit23@gmail.com']" is an invalid value for Author-email. Error: Use a valid email address See https://packaging.python.org/specifications/core-metadata for url: https://upload.pypi.org/legacy/
```

Failed Build: https://travis-ci.org/wikimedia/drafttopic/builds/571420139#L1039

This is a known bug, see: https://bugs.python.org/issue6992