### PR TITLE
Fix broken docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,9 @@ extensions = [
     'm2r'
 ]
 
+# The master toctree document.
+master_doc = 'index'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
The sphinx docs build on Readthedocs is currently failing:
https://readthedocs.org/projects/drafttopic/builds/9605465/

This PR sets the `master_doc` param explicitly to `index` so RTD can build our docs.