### PR TITLE
Relax mid level category directory fetch regex

### DIFF
--- a/drafttopic/utilities/fetch_text.py
+++ b/drafttopic/utilities/fetch_text.py
@@ -103,6 +103,7 @@ def build_fetch_text_extractor(session):
             titles=labeling['talk_page_title'],
             rvlimit=1,
             rvdir="newer",
+            rvslots="main",
             formatversion=2
         )
         page_documents = None
@@ -114,7 +115,7 @@ def build_fetch_text_extractor(session):
         for page_doc in page_documents:
             try:
                 rev_doc = page_doc['revisions'][0]
-                text = rev_doc['content']
+                text = rev_doc['slots']['main']['content']
                 if is_article(text):
                     title = mwtitle.normalize(page_doc['title'])
 

--- a/drafttopic/utilities/fetch_wikiprojects.py
+++ b/drafttopic/utilities/fetch_wikiprojects.py
@@ -61,12 +61,12 @@ wp_section_nextheading_regex = r'(.+)[=]{2,}'
 
 wp_section_regex =\
     r'{{Wikipedia:WikiProject Council/Directory/WikiProject\n'\
-    '\|project = ([a-zA-Z_: -]+)\n'\
-    '\|shortname = ([a-zA-Z\(\) -]+)\n'\
-    '\|active = (yes|no)\n([^}]*)}}'
+    '[ \t]*\|project[ \t]*=[ \t]*([^\n/#]*)\n'\
+    '[ \t]*\|shortname[ \t]*=[ \t]*([^\n]*)\n'\
+    '[ \t]*\|active[ \t]*=[ \t]*(yes|no)\n([^}]*)}}'
 # To check listing in other wikiprojects
 wp_section_regex_listed =\
-    r'listed-in = ([A-Za-z#/:_ ]+)'
+    r'listed-in[ \t]*=[ \t]*([^\s][^n]*)'
 
 wp_main_links_regex1 =\
     r'\[\[Wikipedia:WikiProject Council/Directory/([A-Za-z_ ]+)/([A-Za-z_ ]+)\|([A-Za-z ]+)\]\]'  # noqa: E501


### PR DESCRIPTION
Bug: T229401
Relaxes the regular expression used for generating the mid-level category associations.
Change-Id: I29197a3ce0032e28841124b80b09be85ffbb1ac5